### PR TITLE
Support float value without decimal point

### DIFF
--- a/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
+++ b/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
@@ -359,7 +359,13 @@ public class FilteredPageOutput
                     pageBuilder.setDouble(expandedJsonColumn.getColumn(), value.asFloatValue().toDouble());
                 }
                 catch (MessageTypeCastException e) {
-                    throw new JsonValueInvalidException(String.format("Failed to parse '%s' as double", expandedJsonColumn.getKey()), e);
+                    try {
+                        // ad-hoc workaround for decimal point missing
+                        pageBuilder.setDouble(expandedJsonColumn.getColumn(), (double) value.asIntegerValue().toLong());
+                    }
+                    catch (MessageTypeCastException e2) {
+                        throw new JsonValueInvalidException(String.format("Failed to parse '%s' as double", expandedJsonColumn.getKey()), e);
+                    }
                 }
             }
             else if (Types.LONG.equals(expandedJsonColumn.getColumn().getType())) {


### PR DESCRIPTION
The following parse error occurs when value without decimal point comes in a column defined as double.

### Error message

```
[WARN] (embulk-output-executor-0): Skipped an invalid record (Failed to parse 'point' as double)
```

### Exmaple
`point: 0` is included.

```
{"phone_numbers":"656.669.6277","app_id":792,"point":0,"created_at":"2015-10-09 08:26:17 +0900","profile":{"like_words":["officia","sapiente","quia"],"anniversary":{"ut":"occaecati","et":"recusandae"}}}
```

### Workaround
Added exception handling for supporting type conversion from long to double.
